### PR TITLE
Add quotes and do not rely on fragile ls output

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -2,16 +2,16 @@
 cdp() {
     local project=$1
 
-    if [ -z $PROJECT_DIRECTORIES ]; then
+    if [ -z "$PROJECT_DIRECTORIES" ]; then
         print "You have to set up your \$PROJECT_DIRECTORIES variable"
         return 2
     fi
 
     for dir in ${(s/:/)PROJECT_DIRECTORIES}; do
-        for proj in $(ls $dir); do
-            if [ -d $dir/$proj ] && [ "$proj" = "$project" ]; then
+        for proj in "$dir"/* ; do
+            if [ -d "$proj" ] && [ "$proj:t" = "$project" ]; then
                 print "Found $project in $dir"
-                cd $dir/$proj
+                cd "$proj" || return 1
                 return
             fi
         done


### PR DESCRIPTION
Hey, I am using cdp for quite a while now (thanks).

Recently it broke for me when I enabled auto coloring for ls via an alias (`alias ls='ls --color -h'`).

A workaround would have been to add the `--color=never` flag but I figured instead globbing would be a less fragile approach. I also added some quoting to deal with potential spaces in the paths and thought I share those improvements upstream :)